### PR TITLE
fix: prevent Nuxt Studio from converting date to ISO 8601 full format

### DIFF
--- a/content.config.ts
+++ b/content.config.ts
@@ -10,7 +10,7 @@ const content = defineCollection({
   schema: v.object({
     title: v.optional(v.string()),
     description: v.optional(v.string()),
-    date: v.optional(v.date()),
+    date: v.optional(v.pipe(v.string(), v.regex(/^\d{4}-\d{2}-\d{2}$/))),
     tags: v.optional(v.array(v.string()), []),
     draft: v.optional(v.boolean(), false),
   }),


### PR DESCRIPTION
## Summary
- `content.config.ts` の `date` スキーマを `v.date()` から `v.pipe(v.string(), v.regex(/^\d{4}-\d{2}-\d{2}$/))` に変更
- JSON Schema に `format: "date"` が付与されなくなり、Nuxt Studio による ISO 8601 フルフォーマットへの自動変換を防止

## Test plan
- [ ] Nuxt Studio でコンテンツを編集し、`date` フィールドが `YYYY-MM-DD` のまま保存されることを確認
- [ ] GitHub と Website の間で conflict が発生しないことを確認

Closes #70

🤖 Generated with [Claude Code](https://claude.com/claude-code)