### PR TITLE
fix: pnpm install 時のビルドスクリプト警告を解消

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,15 +6,6 @@
   "engines": {
     "node": ">=24.13"
   },
-  "pnpm": {
-    "overrides": {
-      "chokidar": "^3.6.0"
-    },
-    "onlyBuiltDependencies": [
-      "better-sqlite3",
-      "esbuild"
-    ]
-  },
   "scripts": {
     "build": "nuxt build",
     "dev": "nuxt dev",

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,9 @@
+overrides:
+  chokidar: "^3.6.0"
+
+onlyBuiltDependencies:
+  - "@parcel/watcher"
+  - better-sqlite3
+  - esbuild
+  - sharp
+  - unrs-resolver


### PR DESCRIPTION
## Summary

- pnpm v10 の設定を `package.json` の `pnpm` フィールドから `pnpm-workspace.yaml` に移行
- `onlyBuiltDependencies` に `@parcel/watcher`, `sharp`, `unrs-resolver` を追加し、ビルドスクリプト警告を解消

closes #72

## Test plan

- [ ] `pnpm install` 実行時に `Ignored build scripts` 警告が表示されないことを確認
- [ ] `nuxt dev` / `nuxt build` が正常に動作することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)