### PR TITLE
feat: OGP データ取得 API を追加

### DIFF
--- a/server/api/ogp.get.ts
+++ b/server/api/ogp.get.ts
@@ -1,0 +1,118 @@
+import type { ChildNode, Element } from "parse5/dist/tree-adapters/default";
+import { parse } from "parse5";
+
+interface OgpData {
+  title: string;
+  description: string;
+  image: string;
+  url: string;
+  siteName: string;
+  favicon: string;
+}
+
+function isElement(node: ChildNode): node is Element {
+  return node.nodeName !== "#text" && node.nodeName !== "#comment" && "tagName" in node;
+}
+
+function findElements(node: { childNodes?: ChildNode[] }, tagName: string): Element[] {
+  const results: Element[] = [];
+  if (!node.childNodes) return results;
+  for (const child of node.childNodes) {
+    if (isElement(child)) {
+      if (child.tagName === tagName) {
+        results.push(child);
+      }
+      results.push(...findElements(child, tagName));
+    }
+  }
+  return results;
+}
+
+function getAttr(el: Element, name: string): string | undefined {
+  return el.attrs.find(a => a.name === name)?.value;
+}
+
+function getTextContent(el: Element): string {
+  let text = "";
+  if (!el.childNodes) return text;
+  for (const child of el.childNodes) {
+    if (child.nodeName === "#text" && "value" in child) {
+      text += child.value;
+    }
+    else if (isElement(child)) {
+      text += getTextContent(child);
+    }
+  }
+  return text;
+}
+
+function resolveUrl(base: string, relative: string): string {
+  if (!relative) return "";
+  try {
+    return new URL(relative, base).href;
+  }
+  catch {
+    return relative;
+  }
+}
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event);
+  const url = query.url as string | undefined;
+
+  if (!url) {
+    throw createError({ statusCode: 400, statusMessage: "Missing 'url' query parameter" });
+  }
+
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  }
+  catch {
+    throw createError({ statusCode: 400, statusMessage: "Invalid URL" });
+  }
+
+  let html: string;
+  try {
+    html = await $fetch<string>(url, {
+      headers: {
+        "User-Agent": "bot",
+        "Accept": "text/html",
+      },
+      timeout: 5000,
+      responseType: "text",
+    });
+  }
+  catch {
+    throw createError({ statusCode: 502, statusMessage: "Failed to fetch the target URL" });
+  }
+
+  const document = parse(html);
+  const metaElements = findElements(document, "meta");
+  const titleElements = findElements(document, "title");
+
+  const ogTags: Record<string, string> = {};
+  for (const meta of metaElements) {
+    const property = getAttr(meta, "property") || getAttr(meta, "name");
+    const content = getAttr(meta, "content");
+    if (property && content) {
+      ogTags[property] = content;
+    }
+  }
+
+  const fallbackTitle = titleElements.length > 0 ? getTextContent(titleElements[0]!) : "";
+
+  const ogImage = ogTags["og:image"] || "";
+  const resolvedImage = ogImage ? resolveUrl(url, ogImage) : "";
+
+  const data: OgpData = {
+    title: ogTags["og:title"] || fallbackTitle,
+    description: ogTags["og:description"] || ogTags["description"] || "",
+    image: resolvedImage,
+    url: ogTags["og:url"] || url,
+    siteName: ogTags["og:site_name"] || parsedUrl.hostname,
+    favicon: `https://www.google.com/s2/favicons?domain=${parsedUrl.hostname}&sz=32`,
+  };
+
+  return data;
+});


### PR DESCRIPTION
## Summary

- URL を受け取り対象ページの HTML を取得し、`parse5` で OGP メタタグを解析する API エンドポイント `GET /api/ogp` を追加
- `og:title`, `og:description`, `og:image`, `og:url`, `og:site_name` を抽出し、`<title>` / `<meta name="description">` へのフォールバックも対応
- favicon は Google Favicon API (`https://www.google.com/s2/favicons`) を利用

## Test plan

- [ ] `nr dev` で開発サーバー起動
- [ ] `/api/ogp?url=https://nuxt.com` にアクセスし JSON レスポンスを確認
- [ ] OGP のないサイト、存在しない URL でのエラーハンドリングを確認
- [ ] `url` パラメータ未指定時に 400 エラーが返ることを確認

close #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)