### PR TITLE
fix(link-card): 埋め込みカードのレイアウト安定化と本文幅の調整

### DIFF
--- a/app/assets/css/main.css
+++ b/app/assets/css/main.css
@@ -23,6 +23,10 @@
 
   /* Spacing */
   --max-width: 1200px;
+
+  /* Reading column width for article body (narrower than the layout shell
+     so long lines stay comfortable to read). */
+  --content-width: 760px;
   --header-height: 64px;
 
   /* Header */
@@ -134,7 +138,7 @@ img {
 
 /* Prose - Markdown content */
 .prose {
-  max-width: var(--max-width);
+  max-width: var(--content-width);
   margin-inline: auto;
 
   & > :first-child {

--- a/app/content/link-card.vue
+++ b/app/content/link-card.vue
@@ -7,6 +7,25 @@ const { data, status } = useFetch("/api/ogp", {
   query: { url: props.url },
 });
 
+const imageError = ref(false);
+const faviconError = ref(false);
+
+const thumbImg = useTemplateRef<HTMLImageElement>("thumbImg");
+const faviconImg = useTemplateRef<HTMLImageElement>("faviconImg");
+
+// When the image fails before hydration (e.g. SSR-rendered <img>), the
+// native error event fires before the @error listener is attached and is
+// missed. Re-check on mount: a finished load with no intrinsic size means
+// the image is broken.
+function isBroken(el: HTMLImageElement | null): boolean {
+  return !!el && el.complete && el.naturalWidth === 0;
+}
+
+onMounted(() => {
+  if (isBroken(thumbImg.value)) imageError.value = true;
+  if (isBroken(faviconImg.value)) faviconError.value = true;
+});
+
 const domain = computed(() => {
   try {
     return new URL(props.url).hostname;
@@ -59,24 +78,28 @@ const domain = computed(() => {
       <p v-if="data.description">{{ data.description }}</p>
       <small>
         <img
-          v-if="data.favicon"
+          v-if="data.favicon && !faviconError"
+          ref="faviconImg"
           :src="data.favicon"
           alt=""
           width="16"
           height="16"
           loading="lazy"
+          @error="faviconError = true"
         >
         <span>{{ data.siteName || domain }}</span>
       </small>
     </div>
     <div
-      v-if="data.image"
+      v-if="data.image && !imageError"
       class="thumbnail"
     >
       <img
+        ref="thumbImg"
         :src="data.image"
         alt=""
         loading="lazy"
+        @error="imageError = true"
       >
     </div>
     <span class="sr-only">(新しいタブで開きます)</span>
@@ -164,9 +187,16 @@ const domain = computed(() => {
   }
 
   .thumbnail {
+    position: relative;
     width: 230px;
+    /* Keep the card height driven by the text content, not the image's
+       aspect ratio: the image is absolutely positioned so a square/portrait
+       OG image can't stretch the whole card. */
+    align-self: stretch;
 
     img {
+      position: absolute;
+      inset: 0;
       width: 100%;
       height: 100%;
       object-fit: cover;

--- a/app/pages/[...slug].vue
+++ b/app/pages/[...slug].vue
@@ -58,7 +58,7 @@ defineOgImage({
 .share-section {
   display: flex;
   justify-content: center;
-  max-width: var(--max-width);
+  max-width: var(--content-width);
   margin-inline: auto;
   margin-top: 3rem;
   padding-top: 2rem;

--- a/app/primitives/hero.vue
+++ b/app/primitives/hero.vue
@@ -25,8 +25,10 @@ defineProps<{
 figure {
   position: relative;
   width: 100%;
+  max-width: var(--content-width);
   height: 300px;
-  margin-bottom: 2rem;
+  margin-block: 0 2rem;
+  margin-inline: auto;
   overflow: hidden;
   border-radius: 8px;
 


### PR DESCRIPTION
## 概要

埋め込みリンク（LinkCard）の見た目が崩れやすい問題と、本文カラムが横長すぎて読みにくい問題を修正します。Chrome DevTools で実機検証しながら対応しました。

## 修正した問題（実機確認済み）

| 問題（修正前） | 修正後 |
|---|---|
| カード高さが**OG画像のアスペクト比に依存**して暴れる（X カード=232px、横長画像=129px） | 全カード**高さ統一**、サムネは常に230×127にカバー表示 |
| 画像読込失敗で**白い壊れたボックス**が残る（例: Nuxt Studio） | サムネ/ファビコンを除去しテキストが全幅に |
| 本文が**1200px×22pxフォントで横長すぎ** | `760px` の読みやすい幅に。Hero・共有ボタンも揃えて中央配置 |

## 変更内容

**`app/content/link-card.vue`**
- サムネ画像を `position:absolute` 化 → カード高さが画像比率ではなく本文量で決まるように（潰れ・肥大化を解消）
- 画像/ファビコンの読込失敗時に要素を消す `@error` ハンドリングを追加
- **SSRハイドレーション前にエラーが起きて `@error` を取りこぼす問題**に対し、`onMounted` で「読込完了済みなのに `naturalWidth===0`」を検出するガードを追加

**`app/assets/css/main.css`**
- `--content-width: 760px` を新設し `.prose` に適用

**`app/primitives/hero.vue` / `app/pages/[...slug].vue`**
- Hero バナーと共有セクションも `--content-width` に揃え、記事カラムを一貫した幅で中央寄せ（ヘッダーのバーは従来の広い幅のまま）

## 検証

- デスクトップ／モバイル両方でスクショ確認、リンクカード4種（正常画像・正方形アバター・画像失敗）すべて意図通り
- `oxlint` / `eslint` パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)