### PR TITLE
chore(deps): drop direct @unhead/vue dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,6 @@
     "@nuxtjs/color-mode": "^4.0.1",
     "@nuxtjs/seo": "^5.3.12",
     "@resvg/resvg-js": "^2.6.2",
-    "@unhead/vue": "^2.1.17",
     "@valibot/to-json-schema": "^1.7.1",
     "nuxt": "^4.5.2",
     "nuxt-studio": "^1.7.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,13 +31,10 @@ importers:
         version: 4.0.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       '@nuxtjs/seo':
         specifier: ^5.3.12
-        version: 5.3.12(6c67135c1f6e403c3fbe2384e62369ea)
+        version: 5.3.12(509711610c68187fdef8d1fb10e24588)
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
-      '@unhead/vue':
-        specifier: ^2.1.17
-        version: 2.1.17(vue@3.5.41(typescript@5.9.3))
       '@valibot/to-json-schema':
         specifier: ^1.7.1
         version: 1.7.1(valibot@1.4.2(typescript@5.9.3))
@@ -2663,11 +2660,6 @@ packages:
         optional: true
       webpack:
         optional: true
-
-  '@unhead/vue@2.1.17':
-    resolution: {integrity: sha512-pnC8x9HLV3qQXdvWfylUEU25uhfCAy3ly9nmpQz84j9py818DRfU8jOsQ5wjdWtxyU1vX/fW2udfm4jtxUK8Bg==}
-    peerDependencies:
-      vue: '>=3.5.18'
 
   '@unhead/vue@3.3.1':
     resolution: {integrity: sha512-iS+eiE1NehbV/eF7wzR7UUuUVTv8fIphFOCekQvEMuPqfKPCB8f3wf7sgPgUngYX6mdgM6PmkGmaOQgTBxqwbw==}
@@ -6325,9 +6317,6 @@ packages:
   unenv@2.0.0-rc.24:
     resolution: {integrity: sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==}
 
-  unhead@2.1.17:
-    resolution: {integrity: sha512-HLMKXOszRhAPBrr6VlqCeVeJq2kbC4kXwzGLEZvvojPLWNYTJw22xG7Bfwhsvs31+IBet3Wl8ADg9dwYdyphfQ==}
-
   unhead@3.3.1:
     resolution: {integrity: sha512-eqHlbLyuvIXw898WopQmosTml4PdYW5ZhXDom/sf7ysAqQB9uvYrw2/dNvbrmkJTufSkmNmgGCjoQcvoT2mS/A==}
     peerDependencies:
@@ -8634,16 +8623,16 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/seo@5.3.12(6c67135c1f6e403c3fbe2384e62369ea)':
+  '@nuxtjs/seo@5.3.12(509711610c68187fdef8d1fb10e24588)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       '@nuxtjs/robots': 6.1.4(95434f70512f564202d606652d930f4e)
       '@nuxtjs/sitemap': 8.3.4(95434f70512f564202d606652d930f4e)
       nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.144.0)(@parcel/watcher@2.5.6)(@types/node@25.9.5)(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.143.0)(oxlint@1.78.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.50.0)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(yaml@2.9.0)
       nuxt-link-checker: 5.1.3(66a864c9e8c7a987c52354c417711587)
-      nuxt-og-image: 6.7.8(09a1e5302a62e76b949e5850ac90afde)
-      nuxt-schema-org: 6.2.9(09d6d70843ece1f7492b4fa08d5ffccd)
-      nuxt-seo-utils: 8.4.1(f9a7c8855d67410b3e63c3a6f3db2eb8)
+      nuxt-og-image: 6.7.8(675c7c8e073d6fc774b893d501fb4828)
+      nuxt-schema-org: 6.2.9(3960cdfb8f9ac95af816d98c92bd8586)
+      nuxt-seo-utils: 8.4.1(12b55f7ea7d1c477f66ef17af2e8b99c)
       nuxt-site-config: 4.2.2(95434f70512f564202d606652d930f4e)
       nuxtseo-shared: 5.3.12(39d805cf26f2eed17ceea1d2677ecb49)
     transitivePeerDependencies:
@@ -9643,12 +9632,6 @@ snapshots:
       - bun-types-no-globals
       - rollup
       - unloader
-
-  '@unhead/vue@2.1.17(vue@3.5.41(typescript@5.9.3))':
-    dependencies:
-      hookable: 6.1.1
-      unhead: 2.1.17
-      vue: 3.5.41(typescript@5.9.3)
 
   '@unhead/vue@3.3.1(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.143.0)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))':
     dependencies:
@@ -12605,11 +12588,11 @@ snapshots:
       - vue
       - zod
 
-  nuxt-og-image@6.7.8(09a1e5302a62e76b949e5850ac90afde):
+  nuxt-og-image@6.7.8(675c7c8e073d6fc774b893d501fb4828):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/kit': 4.5.2(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
-      '@unhead/vue': 2.1.17(vue@3.5.41(typescript@5.9.3))
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.143.0)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       '@vue/compiler-sfc': 3.5.41
       chrome-launcher: 1.2.1
       consola: 3.4.2
@@ -12666,7 +12649,7 @@ snapshots:
       - vue
       - webpack
 
-  nuxt-schema-org@6.2.9(09d6d70843ece1f7492b4fa08d5ffccd):
+  nuxt-schema-org@6.2.9(3960cdfb8f9ac95af816d98c92bd8586):
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       defu: 6.1.7
@@ -12675,7 +12658,7 @@ snapshots:
       pkg-types: 2.3.1
       ufo: 1.6.4
     optionalDependencies:
-      '@unhead/vue': 2.1.17(vue@3.5.41(typescript@5.9.3))
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.143.0)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       unhead: 3.3.1(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       zod: 4.4.3
     transitivePeerDependencies:
@@ -12689,7 +12672,7 @@ snapshots:
       - vite
       - vue
 
-  nuxt-seo-utils@8.4.1(f9a7c8855d67410b3e63c3a6f3db2eb8):
+  nuxt-seo-utils@8.4.1(12b55f7ea7d1c477f66ef17af2e8b99c):
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       citty: 0.2.2
@@ -12707,7 +12690,7 @@ snapshots:
       tinyglobby: 0.2.17
       ufo: 1.6.4
     optionalDependencies:
-      '@unhead/vue': 2.1.17(vue@3.5.41(typescript@5.9.3))
+      '@unhead/vue': 3.3.1(@oxc-project/types@0.144.0)(esbuild@0.28.2)(lightningcss@1.33.0)(oxc-parser@0.143.0)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(vue@3.5.41(typescript@5.9.3))
       esbuild: 0.28.2
       lightningcss: 1.33.0
       rolldown: 1.2.4
@@ -14408,10 +14391,6 @@ snapshots:
   unenv@2.0.0-rc.24:
     dependencies:
       pathe: 2.0.3
-
-  unhead@2.1.17:
-    dependencies:
-      hookable: 6.1.1
 
   unhead@3.3.1(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)):
     dependencies:


### PR DESCRIPTION
## 概要

@unhead/vue v3 へのメジャー更新の代わりに、直接依存そのものを削除します。

## 理由

- @unhead/vue は INIT 時からの直接依存ですが、コード中に直接 import は 1 箇所もなく、`useHead` などはすべて Nuxt の auto-import 経由です
- nuxt 4.5.2 は内部で `@unhead/vue ^3.3.1` に依存しており、直接依存の v2 (2.1.17) は古い二重インスタンスとして共存している状態でした
- 直接依存を削除することで Nuxt 管理に一本化され、今後バージョンがズレる余地がなくなります(削除後は `pnpm why @unhead/vue` で 3.3.1 のみが解決されることを確認済み)

## 検証

- [x] `pnpm lint` 成功
- [x] `pnpm build` 成功
- [x] `tsc -p .nuxt/tsconfig.node.json --noEmit` 成功

## 備考

#120 の上に積んでいます。#118 → #119 → #120 → この PR の順にマージしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)