### PR TITLE
chore(deps): update satori to 0.29

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "nuxt": "^4.5.2",
     "nuxt-studio": "^1.7.0",
     "pg": "^8.23.0",
-    "satori": "^0.26.0",
+    "satori": "^0.29.0",
     "valibot": "^1.4.2"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 4.0.1(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       '@nuxtjs/seo':
         specifier: ^5.3.12
-        version: 5.3.12(509711610c68187fdef8d1fb10e24588)
+        version: 5.3.12(e84c1cc99f539253529e6db996298693)
       '@resvg/resvg-js':
         specifier: ^2.6.2
         version: 2.6.2
@@ -48,8 +48,8 @@ importers:
         specifier: ^8.23.0
         version: 8.23.0
       satori:
-        specifier: ^0.26.0
-        version: 0.26.0
+        specifier: ^0.29.0
+        version: 0.29.0
       valibot:
         specifier: ^1.4.2
         version: 1.4.2(typescript@5.9.3)
@@ -5846,8 +5846,8 @@ packages:
   safe-buffer@5.2.1:
     resolution: {integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==}
 
-  satori@0.26.0:
-    resolution: {integrity: sha512-tkMFrfIs3l2mQ2JEcyW0ADTy3zGggFRFzi6Ef8YozQSFsFKEqaSO1Y8F9wJg4//PJGQauMalHGTUEkPrFwhVPA==}
+  satori@0.29.0:
+    resolution: {integrity: sha512-fPAfrwNaIQ7EsJLhY382STEqpczN6ZEH9NsKXDQgRcxUXNNPB73iAjSshzFwTaaScT68pxV0pmG6TBzDQ4sEGw==}
     engines: {node: '>=16'}
 
   sax@1.6.1:
@@ -8623,14 +8623,14 @@ snapshots:
       - vite
       - vue
 
-  '@nuxtjs/seo@5.3.12(509711610c68187fdef8d1fb10e24588)':
+  '@nuxtjs/seo@5.3.12(e84c1cc99f539253529e6db996298693)':
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
       '@nuxtjs/robots': 6.1.4(95434f70512f564202d606652d930f4e)
       '@nuxtjs/sitemap': 8.3.4(95434f70512f564202d606652d930f4e)
       nuxt: 4.5.2(@babel/plugin-syntax-jsx@7.29.7(@babel/core@7.29.7))(@babel/plugin-syntax-typescript@7.29.7(@babel/core@7.29.7))(@oxc-project/types@0.144.0)(@parcel/watcher@2.5.6)(@types/node@25.9.5)(@vue/compiler-sfc@3.5.41)(cac@7.0.0)(db0@0.3.4)(esbuild@0.28.2)(eslint@10.8.1(jiti@2.7.0))(ioredis@5.11.1)(lightningcss@1.33.0)(magicast@0.5.4)(optionator@0.9.4)(oxc-parser@0.143.0)(oxlint@1.78.0)(rolldown@1.2.4)(rollup-plugin-visualizer@7.0.1(rolldown@1.2.4)(rollup@4.62.4))(rollup@4.62.4)(srvx@0.11.22)(terser@5.50.0)(typescript@5.9.3)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))(yaml@2.9.0)
       nuxt-link-checker: 5.1.3(66a864c9e8c7a987c52354c417711587)
-      nuxt-og-image: 6.7.8(675c7c8e073d6fc774b893d501fb4828)
+      nuxt-og-image: 6.7.8(2da43992a6f3ff74a65575a0806bdb4b)
       nuxt-schema-org: 6.2.9(3960cdfb8f9ac95af816d98c92bd8586)
       nuxt-seo-utils: 8.4.1(12b55f7ea7d1c477f66ef17af2e8b99c)
       nuxt-site-config: 4.2.2(95434f70512f564202d606652d930f4e)
@@ -12588,7 +12588,7 @@ snapshots:
       - vue
       - zod
 
-  nuxt-og-image@6.7.8(675c7c8e073d6fc774b893d501fb4828):
+  nuxt-og-image@6.7.8(2da43992a6f3ff74a65575a0806bdb4b):
     dependencies:
       '@clack/prompts': 1.7.0
       '@nuxt/kit': 4.5.2(magic-string@1.1.1)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.4)(unplugin@3.3.0(esbuild@0.28.2)(rolldown@1.2.4)(rollup@4.62.4)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0)))
@@ -12628,7 +12628,7 @@ snapshots:
       fontless: 0.2.1(db0@0.3.4)(ioredis@5.11.1)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       nitropack: 2.13.4(@parcel/watcher@2.5.6)(oxc-parser@0.143.0)(rolldown@1.2.4)(srvx@0.11.22)(vite@8.2.1(@types/node@25.9.5)(esbuild@0.28.2)(jiti@2.7.0)(terser@5.50.0)(yaml@2.9.0))
       playwright-core: 1.57.0
-      satori: 0.26.0
+      satori: 0.29.0
       sharp: 0.34.5
       tailwindcss: 4.3.1
       unifont: 0.7.4
@@ -13809,7 +13809,7 @@ snapshots:
 
   safe-buffer@5.2.1: {}
 
-  satori@0.26.0:
+  satori@0.29.0:
     dependencies:
       '@shuding/opentype.js': 1.4.0-beta.0
       css-background-parser: 0.1.0


### PR DESCRIPTION
## 概要

satori を更新します: `0.26.0` → `0.29.0`(0.x 系のためメジャー相当として個別 PR)

## 互換性

- nuxt-og-image `6.7.8` の optional peer は `satori: >=0.19.2` で範囲内 ✅
- satori はコード中で直接 import されておらず、nuxt-og-image の Satori レンダラー用の依存です

## 検証

- [x] `pnpm lint` 成功
- [x] `pnpm build` 成功
- [x] 生成された OG 画像の日本語描画(Zen Old Mincho)・レイアウトが更新前と変わらないことを目視確認

## 備考

#121 の上に積んでいます。#118 → #119 → #120 → #121 → この PR の順にマージしてください。

🤖 Generated with [Claude Code](https://claude.com/claude-code)